### PR TITLE
Improved animation for sidebar

### DIFF
--- a/static/dnollkse/css/layout.css
+++ b/static/dnollkse/css/layout.css
@@ -102,14 +102,14 @@ body,
     position: absolute;
     left: 0px;
     
-    transition: all 1s ease-in-out;
+    transition: all 0.7s ease-in-out 0.1s;
 
     width: 100%;
 }
 
 #content.pushed {
     position: absolute;
-    left: 450px;
+    left: 115%;
     transition: all 0.7s ease-in-out;
 }
 
@@ -359,7 +359,7 @@ Styling for the sidebar
 #sidebar {
     position: absolute;
 
-    left: -450px;
+    left: -115%;
 
     transition: all 0.7s ease-in-out;
 }
@@ -368,7 +368,7 @@ Styling for the sidebar
     position: absolute;
     left: 0px;
 
-    transition: all 1s ease-in-out;
+    transition: all 0.7s ease-in-out 0.1s;
 }
 
 .social {


### PR DESCRIPTION
Now the navigation sidebar will be hidden from 0 - 549px instead of beginning to be visible at 450px. Same with the content.

The navigation timings are improved as well by using delay instead of animating for 1s on showing and 0.7s on hiding. Now the animation is always 0.7s but has a 0.1s delay when showing.