### PR TITLE
Improved toggleSidebar functionality

### DIFF
--- a/static/dnollkse/js/functions.js
+++ b/static/dnollkse/js/functions.js
@@ -3,6 +3,16 @@ function navbarClick() {
 }
 
 function toggleSidebar() {
+  if($('#content').is('.pushed')) {
+    $('#content').show();
+  } else {
+    setTimeout(function() {
+      $('#content').hide();
+    }, 700);
+  }
   $('#sidebar').toggleClass("visible");
-  $('#content').toggleClass("pushed");
+  // This is needed since otherwise we will miss out on the transition because we just showed the element.
+  setTimeout(function() {
+    $('#content').toggleClass("pushed");
+  }, 0);
 }


### PR DESCRIPTION
When the content is finished being pushed it should hide to prevent side scrolling on the page (maybe the performance is better as well). It should be made visible before being pushed back to make sure we display the fancy transition.

Perhaps the same thing should be done to the sidebar, hiding it when it is out of view.

This might solve issue #17